### PR TITLE
add feature to add supplier

### DIFF
--- a/src/ManageSupplier/supplierManager.ts
+++ b/src/ManageSupplier/supplierManager.ts
@@ -1,0 +1,18 @@
+import { Supplier } from '../Types/types'; 
+import { suppliers,products } from '../Data/data';
+import { v4 as uuidv4 } from 'uuid';
+
+
+export function addSupplier(name: string, email?: string, phone?: string): void {
+  const supplier: Supplier = {
+    id: uuidv4(),
+    name,
+    email,
+    phone,
+  };
+  suppliers.push(supplier);
+  console.log(` Supplier '${name}' added.`);
+}
+
+
+


### PR DESCRIPTION
## Summary

This PR introduces the `addSupplier` function to register suppliers, supporting optional email and phone fields. Each supplier is assigned a UUID.

 Includes:
- Optional chaining for contact fields
- Formatted console output on success